### PR TITLE
fix stub config bug

### DIFF
--- a/src/main/java/com/webank/wecross/stub/fabric/FabricConnectionFactory.java
+++ b/src/main/java/com/webank/wecross/stub/fabric/FabricConnectionFactory.java
@@ -84,7 +84,7 @@ public class FabricConnectionFactory {
             for (String peerAddress : org.getEndorsers()) {
                 String name = "peer-" + String.valueOf(index);
                 peersMap.put(
-                        name, buildPeer(client, peerAddress, org.getTlsCaFile(), orgName, index));
+                        name, buildPeer(client, peerAddress, org.getTlsCaFile(),org.getHostName(),orgName, index));
                 index++;
             }
         }
@@ -121,7 +121,7 @@ public class FabricConnectionFactory {
         orderer1Prop.setProperty("sslProvider", "JDK");
         orderer1Prop.setProperty("negotiationType", "TLS");
         orderer1Prop.setProperty("ordererWaitTimeMilliSecs", "300000");
-        orderer1Prop.setProperty("hostnameOverride", "orderer");
+        orderer1Prop.setProperty("hostnameOverride",  fabricStubConfigParser.getFabricServices().getOrdererHostName());
         orderer1Prop.setProperty("trustServerCertificate", "true");
         orderer1Prop.setProperty("allowAllHostNames", "true");
         Orderer orderer =
@@ -133,14 +133,14 @@ public class FabricConnectionFactory {
     }
 
     public static Peer buildPeer(
-            HFClient client, String address, String tlsCaFile, String orgName, Integer index)
+            HFClient client, String address, String tlsCaFile,String hostName, String orgName, Integer index)
             throws InvalidArgumentException {
         Properties peer0Prop = new Properties();
         peer0Prop.setProperty("pemFile", tlsCaFile);
         // peer0Prop.setProperty("sslProvider", "openSSL");
         peer0Prop.setProperty("sslProvider", "JDK");
         peer0Prop.setProperty("negotiationType", "TLS");
-        peer0Prop.setProperty("hostnameOverride", "peer0");
+        peer0Prop.setProperty("hostnameOverride", hostName);
         peer0Prop.setProperty("trustServerCertificate", "true");
         peer0Prop.setProperty("allowAllHostNames", "true");
         peer0Prop.setProperty(

--- a/src/main/java/com/webank/wecross/stub/fabric/FabricStubConfigParser.java
+++ b/src/main/java/com/webank/wecross/stub/fabric/FabricStubConfigParser.java
@@ -108,11 +108,15 @@ public class FabricStubConfigParser {
             orgUserName = 'fabric1'
             ordererTlsCaFile = 'ordererTlsCaFile'
             ordererAddress = 'grpcs://127.0.0.1:7050'
+            ordererHostName = 'orderer'
+
         */
         private String channelName;
         private String orgUserName;
         private String ordererTlsCaFile;
         private String ordererAddress;
+        private String ordererHostName;
+
 
         public FabricServices(Toml toml, String stubPath) throws Exception {
             channelName = parseString(toml, "fabricServices.channelName");
@@ -123,6 +127,8 @@ public class FabricStubConfigParser {
                                     + File.separator
                                     + parseString(toml, "fabricServices.ordererTlsCaFile"));
             ordererAddress = parseString(toml, "fabricServices.ordererAddress");
+            ordererHostName = parseString(toml, "fabricServices.ordererHostName");
+
         }
 
         public String getChannelName() {
@@ -140,6 +146,11 @@ public class FabricStubConfigParser {
         public String getOrdererAddress() {
             return ordererAddress;
         }
+
+        public String getOrdererHostName() {
+            return ordererHostName;
+        }
+
     }
 
     public static class Orgs {
@@ -149,11 +160,14 @@ public class FabricStubConfigParser {
                 tlsCaFile = 'org1-tlsca.crt'
                 adminName = 'fabric_admin_org1'
                 endorsers = ['grpcs://localhost:7051']
+                hostName = 'peer0'
 
             [orgs.org2]
                 tlsCaFile = 'org2-tlsca.crt'
                 adminName = 'fabric_admin_org1'
                 endorsers = ['grpcs://localhost:9051']
+                hostName = 'peer0'
+
         */
         private Map<String, Org> orgs = new HashMap<>();
 
@@ -183,6 +197,7 @@ public class FabricStubConfigParser {
                 endorsers = ['grpcs://localhost:9051']
             */
             private String tlsCaFile;
+            private String hostName;
             private String adminName;
             private List<String> endorsers;
 
@@ -190,6 +205,7 @@ public class FabricStubConfigParser {
                 tlsCaFile =
                         FabricUtils.getPath(
                                 stubPath + File.separator + parseStringBase(orgMap, "tlsCaFile"));
+                hostName = parseStringBase(orgMap, "hostName");
                 adminName = parseStringBase(orgMap, "adminName");
                 endorsers = parseStringList(orgMap, "endorsers");
             }
@@ -205,6 +221,11 @@ public class FabricStubConfigParser {
             public List<String> getEndorsers() {
                 return endorsers;
             }
+
+            public String getHostName() {
+                return hostName;
+            }
+
         }
     }
 

--- a/src/main/resources/stubs-sample/fabric/stub.toml
+++ b/src/main/resources/stubs-sample/fabric/stub.toml
@@ -7,14 +7,17 @@
     orgUserName = 'fabric_admin'
     ordererTlsCaFile = 'orderer-tlsca.crt'
     ordererAddress = 'grpcs://localhost:7050'
+    ordererHostName = 'orderer'
 
 [orgs]
     [orgs.Org1]
         tlsCaFile = 'org1-tlsca.crt'
         adminName = 'fabric_admin_org1'
         endorsers = ['grpcs://localhost:7051']
+        hostName = 'peer0'
 
     [orgs.Org2]
         tlsCaFile = 'org2-tlsca.crt'
         adminName = 'fabric_admin_org2'
         endorsers = ['grpcs://localhost:9051']
+        hostName = 'peer0'


### PR DESCRIPTION
Added the configuration item that can set the hostname of the Peer node and the Orderer node, which conforms to the fabric network personalization Settings.