### PR TITLE
WeCrossProxy/proxy.go: modify the variable name of hasInfo to isLocke…

### DIFF
--- a/src/main/resources/chaincode/WeCrossProxy/proxy.go
+++ b/src/main/resources/chaincode/WeCrossProxy/proxy.go
@@ -277,9 +277,9 @@ func (p *Proxy) startXATransaction(stub shim.ChaincodeStubInterface, args []stri
 		chaincodeName := getNameFromPath(selfPaths[i])
 		contracts = append(contracts, chaincodeName)
 		var lockedContract LockedContract
-		hasInfo := getLockedContract(stub, chaincodeName, &lockedContract)
+		isLocked := getLockedContract(stub, chaincodeName, &lockedContract)
 		// contract conflict
-		if hasInfo {
+		if isLocked {
 			return shim.Error(selfPaths[i] + " is locked by unfinished xa transaction: " + lockedContract.XATransactionID)
 		}
 		lockedContract = LockedContract{


### PR DESCRIPTION
…d on line 280 and 282.

The variable name of hasInfo gives the misleading impression that the return value of fuction getLockedContract is a hash value. In addition, the fuction of getLockedContract calls return value variable names remain the same.

Signed-off-by: yjwxfq <yjwxfq@163.com>